### PR TITLE
Added support for ignored files and folders. See issue #17

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+max_line_length = 100
+
+
+[*.go]
+indent_style = space
+indent_size = 4

--- a/dogo.go
+++ b/dogo.go
@@ -5,213 +5,213 @@
 package main
 
 import (
-	"fmt"
-	"os"
-	"os/exec"
-	"path/filepath"
-	"runtime"
-	"strings"
-	"time"
+    "fmt"
+    "os"
+    "os/exec"
+    "path/filepath"
+    "runtime"
+    "strings"
+    "time"
 
-	"github.com/zhgo/console"
+    "github.com/zhgo/console"
 )
 
 //Dogo struct
 type Dogo struct {
-	//source files
-	SourceDir []string
+    //source files
+    SourceDir []string
 
-	//source files
-	sourceDir []string
+    //source files
+    sourceDir []string
 
-	//file extends
-	SourceExt []string
+    //file extends
+    SourceExt []string
 
-	//Working Dir
-	WorkingDir string
+    //Working Dir
+    WorkingDir string
 
-	//build command
-	BuildCmd string
+    //build command
+    BuildCmd string
 
-	//run command
-	RunCmd string
+    //run command
+    RunCmd string
 
-	//Decreasing
-	Decreasing uint8
+    //Decreasing
+    Decreasing uint8
 
-	//file list
-	Files map[string]time.Time
+    //file list
+    Files map[string]time.Time
 
-	//Ignored
-	Ignored []string
+    //Ignored
+    Ignored []string
 
-	//Cmd object
-	cmd *exec.Cmd
+    //Cmd object
+    cmd *exec.Cmd
 
-	//file modified
-	isModified bool
+    //file modified
+    isModified bool
 }
 
 //start new monitor
 func (d *Dogo) NewMonitor() {
-	if d.WorkingDir == "" {
-		d.WorkingDir = console.WorkingDir
-	}
-	if len(d.SourceDir) == 0 {
-		d.SourceDir = append(d.SourceDir, console.WorkingDir)
-	}
-	if d.SourceExt == nil || len(d.SourceExt) == 0 {
-		d.SourceExt = []string{".c", ".cpp", ".go", ".h"}
-	}
-	if d.BuildCmd == "" {
-		d.BuildCmd = "go build ."
-	}
-	if d.RunCmd == "" {
-		d.RunCmd = filepath.Base(console.WorkingDir)
-		if runtime.GOOS == "windows" {
-			d.RunCmd += ".exe"
-		}
-	}
+    if d.WorkingDir == "" {
+        d.WorkingDir = console.WorkingDir
+    }
+    if len(d.SourceDir) == 0 {
+        d.SourceDir = append(d.SourceDir, console.WorkingDir)
+    }
+    if d.SourceExt == nil || len(d.SourceExt) == 0 {
+        d.SourceExt = []string{".c", ".cpp", ".go", ".h"}
+    }
+    if d.BuildCmd == "" {
+        d.BuildCmd = "go build ."
+    }
+    if d.RunCmd == "" {
+        d.RunCmd = filepath.Base(console.WorkingDir)
+        if runtime.GOOS == "windows" {
+            d.RunCmd += ".exe"
+        }
+    }
 
-	// Append the current directory to the PATH for compatible linux.
-	console.Setenv("PATH", console.Getenv("PATH")+string(os.PathListSeparator)+d.WorkingDir)
+    // Append the current directory to the PATH for compatible linux.
+    console.Setenv("PATH", console.Getenv("PATH")+string(os.PathListSeparator)+d.WorkingDir)
 
-	console.Chdir(d.WorkingDir)
-	fmt.Printf("[dogo] Working Directory:\n")
-	fmt.Printf("       %s\n", d.WorkingDir)
+    console.Chdir(d.WorkingDir)
+    fmt.Printf("[dogo] Working Directory:\n")
+    fmt.Printf("       %s\n", d.WorkingDir)
 
-	if len(d.Ignored) > 0 {
-		fmt.Printf("[dogo] Ignoring:\n")
-		for i, ignored := range d.Ignored {
-			if !filepath.IsAbs(ignored) {
-				absPath, err := filepath.Abs(ignored)
-				if err != nil {
-					fmt.Printf("Resource %s not found, skipping", ignored)
-				} else {
-					d.Ignored[i] = absPath
-					fmt.Printf("       %s\n", d.Ignored[i])
-				}
-			}
-		}
-	}
+    if len(d.Ignored) > 0 {
+        fmt.Printf("[dogo] Ignoring:\n")
+        for i, ignored := range d.Ignored {
+            if !filepath.IsAbs(ignored) {
+                absPath, err := filepath.Abs(ignored)
+                if err != nil {
+                    fmt.Printf("Resource %s not found, skipping", ignored)
+                } else {
+                    d.Ignored[i] = absPath
+                    fmt.Printf("       %s\n", d.Ignored[i])
+                }
+            }
+        }
+    }
 
-	fmt.Printf("[dogo] Monitoring Directories:\n")
-	for _, dir := range d.SourceDir {
-		fmt.Printf("       %s\n", dir)
-	}
+    fmt.Printf("[dogo] Monitoring Directories:\n")
+    for _, dir := range d.SourceDir {
+        fmt.Printf("       %s\n", dir)
+    }
 
-	fmt.Printf("[dogo] File extends:\n")
-	fmt.Printf("       %s\n", d.SourceExt)
+    fmt.Printf("[dogo] File extends:\n")
+    fmt.Printf("       %s\n", d.SourceExt)
 
-	fmt.Printf("[dogo] Build command:\n")
-	fmt.Printf("       %s\n", d.BuildCmd)
+    fmt.Printf("[dogo] Build command:\n")
+    fmt.Printf("       %s\n", d.BuildCmd)
 
-	fmt.Printf("[dogo] Run command:\n")
-	fmt.Printf("       %s\n", d.RunCmd)
+    fmt.Printf("[dogo] Run command:\n")
+    fmt.Printf("       %s\n", d.RunCmd)
 
-	d.Files = make(map[string]time.Time)
-	d.InitFiles()
+    d.Files = make(map[string]time.Time)
+    d.InitFiles()
 
-	//TODO: add console support.
-	//TODO: Multi commands.
+    //TODO: add console support.
+    //TODO: Multi commands.
 }
 
 func (d *Dogo) InitFiles() {
-	//scan source directories
-	for _, dir := range d.SourceDir {
-		filepath.Walk(dir, func(path string, f os.FileInfo, err error) error {
-			if err != nil {
-				fmt.Printf("%s\n", err)
-				return err
-			}
+    //scan source directories
+    for _, dir := range d.SourceDir {
+        filepath.Walk(dir, func(path string, f os.FileInfo, err error) error {
+            if err != nil {
+                fmt.Printf("%s\n", err)
+                return err
+            }
 
-			if f.IsDir() {
-				if d.isDirectoryIgnored(path) {
-					return nil
-				}
-				d.sourceDir = append(d.sourceDir, path)
-			} else {
-				if d.isFileIgnored(path) {
-					return nil
-				}
-			}
+            if f.IsDir() {
+                if d.isDirectoryIgnored(path) {
+                    return nil
+                }
+                d.sourceDir = append(d.sourceDir, path)
+            } else {
+                if d.isFileIgnored(path) {
+                    return nil
+                }
+            }
 
-			for _, ext := range d.SourceExt {
-				if filepath.Ext(path) == ext {
-					d.Files[path] = f.ModTime()
-					break
-				}
-			}
+            for _, ext := range d.SourceExt {
+                if filepath.Ext(path) == ext {
+                    d.Files[path] = f.ModTime()
+                    break
+                }
+            }
 
-			return nil
-		})
-	}
+            return nil
+        })
+    }
 }
 
 func (d *Dogo) BuildAndRun() {
-	if d.cmd != nil && d.cmd.Process != nil {
-		fmt.Printf("[dogo] Terminate the process %d: ", d.cmd.Process.Pid)
+    if d.cmd != nil && d.cmd.Process != nil {
+        fmt.Printf("[dogo] Terminate the process %d: ", d.cmd.Process.Pid)
 
-		if err := d.cmd.Process.Kill(); err != nil {
-			fmt.Printf("\n%s %s\n", d.cmd.ProcessState.String(), err)
-		} else {
-			fmt.Printf("%s\n", d.cmd.ProcessState.String())
-		}
-	}
+        if err := d.cmd.Process.Kill(); err != nil {
+            fmt.Printf("\n%s %s\n", d.cmd.ProcessState.String(), err)
+        } else {
+            fmt.Printf("%s\n", d.cmd.ProcessState.String())
+        }
+    }
 
-	if err := d.Build(); err != nil {
-		fmt.Printf("[dogo] Build failed: %s\n\n", err)
-	} else {
-		fmt.Printf("[dogo] Start the process: %s\n\n", d.RunCmd)
-		go d.Run()
-	}
+    if err := d.Build(); err != nil {
+        fmt.Printf("[dogo] Build failed: %s\n\n", err)
+    } else {
+        fmt.Printf("[dogo] Start the process: %s\n\n", d.RunCmd)
+        go d.Run()
+    }
 }
 
 //build
 func (d *Dogo) Build() error {
-	fmt.Printf("[dogo] Start build: ")
+    fmt.Printf("[dogo] Start build: ")
 
-	args := console.ParseText(d.BuildCmd)
-	out, err := exec.Command(args[0], args[1:]...).CombinedOutput()
-	if err != nil {
-		fmt.Printf("\n%s", string(out))
-		return err
-	}
+    args := console.ParseText(d.BuildCmd)
+    out, err := exec.Command(args[0], args[1:]...).CombinedOutput()
+    if err != nil {
+        fmt.Printf("\n%s", string(out))
+        return err
+    }
 
-	fmt.Printf("success.\n")
-	return nil
+    fmt.Printf("success.\n")
+    return nil
 }
 
 //run it
 func (d *Dogo) Run() {
-	args := console.ParseText(d.RunCmd)
+    args := console.ParseText(d.RunCmd)
 
-	d.cmd = exec.Command(args[0], args[1:]...)
-	d.cmd.Stdin = os.Stdin
-	d.cmd.Stdout = os.Stdout
-	d.cmd.Stderr = os.Stderr
-	err := d.cmd.Run()
-	if err != nil {
-		fmt.Printf("%s\n", err)
-	}
+    d.cmd = exec.Command(args[0], args[1:]...)
+    d.cmd.Stdin = os.Stdin
+    d.cmd.Stdout = os.Stdout
+    d.cmd.Stderr = os.Stderr
+    err := d.cmd.Run()
+    if err != nil {
+        fmt.Printf("%s\n", err)
+    }
 
-	d.cmd = nil
+    d.cmd = nil
 }
 
 func (d *Dogo) isDirectoryIgnored(path string) bool {
-	for _, ignored := range d.Ignored {
-		if ignored == path {
-			return true
-		}
-	}
-	return false
+    for _, ignored := range d.Ignored {
+        if ignored == path {
+            return true
+        }
+    }
+    return false
 }
 
 func (d *Dogo) isFileIgnored(path string) bool {
-	for _, ignored := range d.Ignored {
-		if strings.HasPrefix(path, ignored) {
-			return true
-		}
-	}
-	return false
+    for _, ignored := range d.Ignored {
+        if strings.HasPrefix(path, ignored) {
+            return true
+        }
+    }
+    return false
 }

--- a/dogo.json
+++ b/dogo.json
@@ -1,10 +1,10 @@
 {
-  "WorkingDir": "{GOPATH}/src/github.com/samacs/dogo/example",
+  "WorkingDir": "{GOPATH}/src/github.com/liudng/dogo/example",
   "SourceDir": [
-    "{GOPATH}/src/github.com/samacs/dogo/example"
+    "{GOPATH}/src/github.com/liudng/dogo/example"
   ],
   "SourceExt": [".c", ".cpp", ".go", ".h"],
-  "BuildCmd": "go build github.com/samacs/dogo/example",
+  "BuildCmd": "go build github.com/liudng/dogo/example",
   "RunCmd": "example",
   "Decreasing": 1,
   "Ignored": ["vendor", "ignored.go"]

--- a/dogo.json
+++ b/dogo.json
@@ -1,10 +1,11 @@
 {
-  "WorkingDir": "{GOPATH}/src/github.com/liudng/dogo/example",
+  "WorkingDir": "{GOPATH}/src/github.com/samacs/dogo/example",
   "SourceDir": [
-    "{GOPATH}/src/github.com/liudng/dogo/example"
+    "{GOPATH}/src/github.com/samacs/dogo/example"
   ],
   "SourceExt": [".c", ".cpp", ".go", ".h"],
-  "BuildCmd": "go build github.com/liudng/dogo/example",
+  "BuildCmd": "go build github.com/samacs/dogo/example",
   "RunCmd": "example",
-  "Decreasing": 1
+  "Decreasing": 1,
+  "Ignored": ["vendor", "ignored.go"]
 }

--- a/dogo_test.go
+++ b/dogo_test.go
@@ -13,8 +13,15 @@ func TestInitFiles(t *testing.T) {
 
 	dogo.NewMonitor()
 
+	// TODO: Configuration is not being loaded here so, being that
+	//       the ignored files and folders were added, I had to change
+	//       the number of files here from 9 to 11.
+	//       I think that a better way would be to load a test configuration
+	//       file in order to have more control over the tests output and
+	//       so be able to test that `dogo.Files` does not contains ignored
+	//       files or folders.
 	l := len(dogo.Files)
-	if l != 9 {
+	if l != 11 {
 		t.Fatalf("Init source files failed: %d.\n", l)
 	}
 }

--- a/example/ignored.go
+++ b/example/ignored.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func ignored() {
+	fmt.Println("I'm an ignored file")
+}

--- a/example/main.go
+++ b/example/main.go
@@ -10,6 +10,6 @@ import (
 )
 
 func main() {
-	log.Println("Some text here.\n")
+	log.Println("Some text here")
 	//log.Fatal(http.ListenAndServe(":8080", http.FileServer(http.Dir("e:/home"))))
 }

--- a/example/main.go
+++ b/example/main.go
@@ -5,11 +5,11 @@
 package main
 
 import (
-	"log"
-	//"net/http"
+    "log"
+    //"net/http"
 )
 
 func main() {
-	log.Println("Some text here")
-	//log.Fatal(http.ListenAndServe(":8080", http.FileServer(http.Dir("e:/home"))))
+    log.Println("Some text here")
+    //log.Fatal(http.ListenAndServe(":8080", http.FileServer(http.Dir("e:/home"))))
 }

--- a/example/vendor/test.go
+++ b/example/vendor/test.go
@@ -1,0 +1,7 @@
+package main
+
+import "log"
+
+func main() {
+	log.Println("From vendor")
+}

--- a/main.go
+++ b/main.go
@@ -7,10 +7,11 @@ package main
 import (
     "flag"
     "fmt"
-    "github.com/zhgo/config"
-    "github.com/zhgo/console"
     "runtime"
     "strings"
+
+    "github.com/zhgo/config"
+    "github.com/zhgo/console"
 )
 
 func main() {


### PR DESCRIPTION
Just added `Ignored` field to JSON configuration and the `Dogo` struct to deal with ignored folders and files under the ignored folders.

If the resource being checked is a folder it is just skipped from adding to the `Dogo.sourceDir`. All subsequent files under that directory are also ignored.

I think it would have been easier to use `map[string]string` for the `Dogo.Ignored` field to perform a 1:1 search but I think it's easier to write only an array of files/folders in the JSON file.